### PR TITLE
Stop on proxy send fail (matches read fail handling).

### DIFF
--- a/include/bitcoin/network/message_subscriber.hpp
+++ b/include/bitcoin/network/message_subscriber.hpp
@@ -115,14 +115,12 @@ public:
     {
         const auto message = std::make_shared<Message>();
 
+        // Subscribers are invoked only with stop and success codes.
         if (!message->from_data(version, stream))
-        {
-            subscriber->relay(error::bad_stream, {});
             return error::bad_stream;
-        }
 
-        const auto const_ptr = std::const_pointer_cast<const Message>(message);
-        subscriber->relay(error::success, const_ptr);
+        ////const auto const_ptr = std::const_pointer_cast<const Message>(message);
+        subscriber->relay(error::success, message);
         return error::success;
     }
 
@@ -139,14 +137,12 @@ public:
     {
         const auto message = std::make_shared<Message>();
 
+        // Subscribers are invoked only with stop and success codes.
         if (!message->from_data(version, stream))
-        {
-            subscriber->invoke(error::bad_stream, {});
             return error::bad_stream;
-        }
 
-        const auto const_ptr = std::const_pointer_cast<const Message>(message);
-        subscriber->invoke(error::success, const_ptr);
+        ////const auto const_ptr = std::const_pointer_cast<const Message>(message);
+        subscriber->invoke(error::success, message);
         return error::success;
     }
 

--- a/include/bitcoin/network/protocols/protocol.hpp
+++ b/include/bitcoin/network/protocols/protocol.hpp
@@ -115,6 +115,9 @@ protected:
     /// Stop the channel (and the protocol).
     virtual void stop(const code& ec);
 
+protected:
+    void handle_send(const code& ec, const std::string& command);
+
 private:
     threadpool& pool_;
     channel::ptr channel_;

--- a/include/bitcoin/network/protocols/protocol_events.hpp
+++ b/include/bitcoin/network/protocols/protocol_events.hpp
@@ -71,9 +71,6 @@ protected:
      */
     virtual bool stopped(const code& ec) const;
 
-protected:
-    void handle_send(const code& ec, const std::string& command);
-
 private:
     void handle_started(completion_handler handler);
     void handle_stopped(const code& ec);

--- a/include/bitcoin/network/protocols/protocol_version_31402.hpp
+++ b/include/bitcoin/network/protocols/protocol_version_31402.hpp
@@ -69,9 +69,6 @@ public:
 protected:
     virtual message::version version_factory() const;
 
-    virtual void handle_version_sent(const code& ec);
-    virtual void handle_verack_sent(const code& ec);
-
     virtual bool handle_receive_version(const code& ec,
         version_const_ptr version);
     virtual bool handle_receive_verack(const code& ec, verack_const_ptr);

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -76,17 +76,17 @@ void channel::do_start(const code& ec, result_handler handler)
 
 bool channel::notify() const
 {
-    return notify_.load();
+    return notify_;
 }
 
 void channel::set_notify(bool value)
 {
-    notify_.store(value);
+    notify_ = value;
 }
 
 uint64_t channel::nonce() const
 {
-    return nonce_.load();
+    return nonce_;
 }
 
 void channel::set_nonce(uint64_t value)

--- a/src/p2p.cpp
+++ b/src/p2p.cpp
@@ -325,7 +325,7 @@ void p2p::set_top_block(const checkpoint& top)
 
 bool p2p::stopped() const
 {
-    return stopped_.load();
+    return stopped_;
 }
 
 threadpool& p2p::thread_pool()

--- a/src/protocols/protocol.cpp
+++ b/src/protocols/protocol.cpp
@@ -82,5 +82,12 @@ void protocol::stop(const code& ec)
     channel_->stop(ec);
 }
 
+// protected
+void protocol::handle_send(const code& ec, const std::string& command)
+{
+    // Send and receive failures are logged by the proxy.
+    // This provides a convenient location for override if desired.
+}
+
 } // namespace network
 } // namespace libbitcoin

--- a/src/protocols/protocol_address_31402.cpp
+++ b/src/protocols/protocol_address_31402.cpp
@@ -86,15 +86,6 @@ bool protocol_address_31402::handle_receive_address(const code& ec,
     if (stopped(ec))
         return false;
 
-    if (ec)
-    {
-        LOG_DEBUG(LOG_NETWORK)
-            << "Failure receiving address message from ["
-            << authority() << "] " << ec.message();
-        stop(ec);
-        return false;
-    }
-
     LOG_DEBUG(LOG_NETWORK)
         << "Storing addresses from [" << authority() << "] ("
         << message->addresses().size() << ")";
@@ -111,15 +102,6 @@ bool protocol_address_31402::handle_receive_get_address(const code& ec,
 {
     if (stopped(ec))
         return false;
-
-    if (ec)
-    {
-        LOG_DEBUG(LOG_NETWORK)
-            << "Failure receiving get_address message from ["
-            << authority() << "] " << ec.message();
-        stop(ec);
-        return false;
-    }
 
     // TODO: allowing repeated queries can allow a channel to map our history.
     // TODO: pull active hosts from host cache (currently just resending self).

--- a/src/protocols/protocol_events.cpp
+++ b/src/protocols/protocol_events.cpp
@@ -98,22 +98,5 @@ void protocol_events::set_event(const code& ec)
     handler(ec);
 }
 
-// Send Handler.
-// ----------------------------------------------------------------------------
-
-void protocol_events::handle_send(const code& ec, const std::string& command)
-{
-    if (stopped(ec))
-        return;
-
-    if (ec)
-    {
-        LOG_DEBUG(LOG_NETWORK)
-            << "Failure sending '" << command << "' to [" << authority()
-            << "] " << ec.message();
-        stop(ec);
-    }
-}
-
 } // namespace network
 } // namespace libbitcoin

--- a/src/protocols/protocol_ping_31402.cpp
+++ b/src/protocols/protocol_ping_31402.cpp
@@ -76,15 +76,6 @@ bool protocol_ping_31402::handle_receive_ping(const code& ec,
     if (stopped(ec))
         return false;
 
-    if (ec)
-    {
-        LOG_DEBUG(LOG_NETWORK)
-            << "Failure getting ping from [" << authority() << "] "
-            << ec.message();
-        stop(ec);
-        return false;
-    }
-
     // RESUBSCRIBE
     return true;
 }

--- a/src/protocols/protocol_seed_31402.cpp
+++ b/src/protocols/protocol_seed_31402.cpp
@@ -95,19 +95,7 @@ bool protocol_seed_31402::handle_receive_address(const code& ec,
     address_const_ptr message)
 {
     if (stopped(ec))
-    {
-        set_event(ec);
         return false;
-    }
-
-    if (ec)
-    {
-        LOG_DEBUG(LOG_NETWORK)
-            << "Failure receiving addresses from seed [" << authority() << "] "
-            << ec.message();
-        set_event(ec);
-        return false;
-    }
 
     LOG_DEBUG(LOG_NETWORK)
         << "Storing addresses from seed [" << authority() << "] ("
@@ -121,19 +109,7 @@ bool protocol_seed_31402::handle_receive_address(const code& ec,
 void protocol_seed_31402::handle_send_address(const code& ec)
 {
     if (stopped(ec))
-    {
-        set_event(ec);
         return;
-    }
-
-    if (ec)
-    {
-        LOG_DEBUG(LOG_NETWORK)
-            << "Failure sending address to seed [" << authority() << "] "
-            << ec.message();
-        set_event(ec);
-        return;
-    }
 
     // 1 of 3
     set_event(error::success);
@@ -142,10 +118,7 @@ void protocol_seed_31402::handle_send_address(const code& ec)
 void protocol_seed_31402::handle_send_get_address(const code& ec)
 {
     if (stopped(ec))
-    {
-        set_event(ec);
         return;
-    }
 
     if (ec)
     {
@@ -163,10 +136,7 @@ void protocol_seed_31402::handle_send_get_address(const code& ec)
 void protocol_seed_31402::handle_store_addresses(const code& ec)
 {
     if (stopped(ec))
-    {
-        set_event(ec);
         return;
-    }
 
     if (ec)
     {

--- a/src/protocols/protocol_version_31402.cpp
+++ b/src/protocols/protocol_version_31402.cpp
@@ -84,7 +84,7 @@ void protocol_version_31402::start(event_handler handler)
 
     SUBSCRIBE2(version, handle_receive_version, _1, _2);
     SUBSCRIBE2(verack, handle_receive_verack, _1, _2);
-    SEND1(version_factory(), handle_version_sent, _1);
+    SEND2(version_factory(), handle_send, _1, version::command);
 }
 
 message::version protocol_version_31402::version_factory() const
@@ -118,10 +118,7 @@ bool protocol_version_31402::handle_receive_version(const code& ec,
     version_const_ptr message)
 {
     if (stopped(ec))
-    {
-        set_event(ec);
         return false;
-    }
 
     if (ec)
     {
@@ -216,7 +213,7 @@ bool protocol_version_31402::handle_receive_version(const code& ec,
         << "Negotiated protocol version (" << version
         << ") for [" << authority() << "]";
 
-    SEND1(verack(), handle_verack_sent, _1);
+    SEND2(verack(), handle_send, _1, verack::command);
 
     // 1 of 2
     set_event(error::success);
@@ -227,10 +224,7 @@ bool protocol_version_31402::handle_receive_verack(const code& ec,
     verack_const_ptr)
 {
     if (stopped(ec))
-    {
-        set_event(ec);
         return false;
-    }
 
     if (ec)
     {
@@ -244,42 +238,6 @@ bool protocol_version_31402::handle_receive_verack(const code& ec,
     // 2 of 2
     set_event(error::success);
     return false;
-}
-
-void protocol_version_31402::handle_version_sent(const code& ec)
-{
-    if (stopped(ec))
-    {
-        set_event(ec);
-        return;
-    }
-
-    if (ec)
-    {
-        LOG_DEBUG(LOG_NETWORK)
-            << "Failure sending version to [" << authority() << "] "
-            << ec.message();
-        set_event(ec);
-        return;
-    }
-}
-
-void protocol_version_31402::handle_verack_sent(const code& ec)
-{
-    if (stopped(ec))
-    {
-        set_event(ec);
-        return;
-    }
-
-    if (ec)
-    {
-        LOG_DEBUG(LOG_NETWORK)
-            << "Failure sending verack to [" << authority() << "] "
-            << ec.message();
-        set_event(ec);
-        return;
-    }
 }
 
 } // namespace network

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -272,6 +272,7 @@ void proxy::handle_send(const boost_code& ec, size_t, command_ptr command,
         LOG_DEBUG(LOG_NETWORK)
             << "Failure sending " << *command << " payload to [" << authority()
             << "] (" << size << " bytes) " << error.message();
+        stop(ec);
     }
 
     LOG_DEBUG(LOG_NETWORK)

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -215,6 +215,8 @@ void proxy::handle_read_payload(const boost_code& ec, size_t payload_size,
     // Notify subscribers of the new message.
     payload_source source(payload_buffer_);
     payload_stream istream(source);
+
+    // Failures are not forwarded to subscribers and channel is stopped below.
     const auto code = message_subscriber_.load(head.type(), version_, istream);
     const auto consumed = istream.peek() == std::istream::traits_type::eof();
 


### PR DESCRIPTION
This simplifies send and receive error handling by relying on the proxy to log start and stop failures and to stop the channel before send/receive handlers are invoked.

This prevents the invoke of message handlers in the case of receive failure and instead stops the channel with a stop code and stops the subscriber with the offending failure condition code. Therefore the message subscribers need only handle stop conditions and success while the stop subscribers still receive the error condition. This prevents the need for arbitrary error handling and logging at the beginning of all message subscribers. The `protocol_events::stopped(code)` method is now sufficient for testing all send/receive handler error codes.