### PR TITLE
Remove connection delay in case of success code.

### DIFF
--- a/include/bitcoin/network/sessions/session.hpp
+++ b/include/bitcoin/network/sessions/session.hpp
@@ -113,11 +113,12 @@ protected:
         dispatch_.delayed(delay, handler);
     }
 
-    /// Delay timing for a tight connection loop, based on configured timeout.
+    /// Delay timing for a tight failure loop, based on configured timeout.
     inline asio::duration cycle_delay(const code& ec)
     {
-        return (ec == error::channel_timeout || ec == error::service_stopped) ?
-            asio::seconds(0) : settings_.connect_timeout();
+        return (ec == error::channel_timeout || ec == error::service_stopped ||
+            ec == error::success) ? asio::seconds(0) :
+            settings_.connect_timeout();
     }
 
     /// Properties.

--- a/src/sessions/session_inbound.cpp
+++ b/src/sessions/session_inbound.cpp
@@ -123,7 +123,7 @@ void session_inbound::handle_accept(const code& ec, channel::ptr channel)
         return;
     }
 
-    // Start accepting again with conditional delay, regardless of error.
+    // Start accepting with conditional delay in case of network error.
     dispatch_delayed(cycle_delay(ec), BIND1(start_accept, _1));
 
     if (ec)

--- a/src/sessions/session_manual.cpp
+++ b/src/sessions/session_manual.cpp
@@ -123,7 +123,7 @@ void session_manual::handle_connect(const code& ec, channel::ptr channel,
 
         if (remaining > 0)
         {
-            // Retry with conditional delay, regardless of error.
+            // Retry with conditional delay in case of network error.
             dispatch_delayed(cycle_delay(ec),
                 BIND5(start_connect, _1, hostname, port, remaining, handler));
             return;

--- a/src/sessions/session_outbound.cpp
+++ b/src/sessions/session_outbound.cpp
@@ -98,7 +98,7 @@ void session_outbound::handle_connect(const code& ec, channel::ptr channel)
         LOG_DEBUG(LOG_NETWORK)
             << "Failure connecting outbound: " << ec.message();
 
-        // Retry with conditional delay, regardless of error.
+        // Retry with conditional delay in case of network error.
         dispatch_delayed(cycle_delay(ec), BIND1(new_connection, _1));
         return;
     }


### PR DESCRIPTION
This caused failures in inbound connection due to unintended timeout. Thanks to @garceri for tracking this issue down!