### PR TITLE
handle_receive_pong should return true on success

### DIFF
--- a/src/protocols/protocol_ping_60001.cpp
+++ b/src/protocols/protocol_ping_60001.cpp
@@ -133,7 +133,7 @@ bool protocol_ping_60001::handle_receive_pong(const code& ec,
         return false;
     }
 
-    return false;
+    return true;
 }
 
 } // namespace network


### PR DESCRIPTION
The problems discussed in https://github.com/libbitcoin/libbitcoin-node/issues/396 have prevented libbitcoin from receiving pong messages. We may never have received a pong message, ever, because of the bugs impacting message queue processing and inbound/outbound timeouts. There will be systemic consequences to fixing these problems, as the entire network behavior of libbitcoin is changed when channels are allowed to stay open until actual errors or real timeouts are detected.