### PR TITLE
Fix ping pong message handling, timeouts, Proactor model state machine hybrid

### DIFF
--- a/include/bitcoin/network/protocols/protocol.hpp
+++ b/include/bitcoin/network/protocols/protocol.hpp
@@ -122,11 +122,11 @@ protected:
 
 protected:
     void handle_send(const system::code& ec, const std::string& command);
+    channel::ptr channel_;
 
 private:
     system::threadpool& pool_;
     system::dispatcher dispatch_;
-    channel::ptr channel_;
     const std::string name_;
 };
 

--- a/include/bitcoin/network/protocols/protocol_ping_60001.hpp
+++ b/include/bitcoin/network/protocols/protocol_ping_60001.hpp
@@ -35,7 +35,7 @@ namespace network {
 class p2p;
 
 /**
- * Ping-pong protocol.
+ * Ping-pong protocol implementing BIP31
  * Attach this to a channel immediately following handshake completion.
  */
 class BCT_API protocol_ping_60001
@@ -57,11 +57,13 @@ protected:
     void handle_send_ping(const system::code& ec, const std::string& command);
     bool handle_receive_ping(const system::code& ec,
         system::ping_const_ptr message) override;
-    virtual bool handle_receive_pong(const system::code& ec,
-        system::pong_const_ptr message, uint64_t nonce);
+    void handle_send_pong(const system::code& ec, const std::string&);
+    bool handle_receive_pong(const system::code& ec,
+        system::pong_const_ptr message, uint64_t nonce_in);
 
 private:
-    std::atomic<bool> pending_;
+    uint64_t nonce;
+    std::atomic<short int> pending_;
 };
 
 } // namespace network

--- a/include/bitcoin/network/proxy.hpp
+++ b/include/bitcoin/network/proxy.hpp
@@ -93,6 +93,19 @@ public:
     /// Stop reading or sending messages on this socket.
     virtual void stop(const system::code& ec);
 
+    // if we have been pinged, don't send the peer long-running commands such as getdata
+    // until after we send our pong, or else the peer may disconnect due to ping timeout.
+    bool pinged();
+    void set_pinged(bool pinged);
+
+    // or if we sent a ping and peer has not yet replied with a pong, delay new commands.
+    bool ponged();
+    void set_ponged(bool ponged);
+
+    /// Get or set the channel state.
+    bool active() const;
+    void set_active(bool state);
+
 protected:
     virtual bool stopped() const;
     virtual void signal_activity() = 0;
@@ -120,6 +133,10 @@ private:
         command_ptr command, payload_ptr payload, result_handler handler);
 
     const system::config::authority authority_;
+
+    std::atomic<bool> pinged_;
+    std::atomic<bool> ponged_;
+    std::atomic<bool> active_;
 
     // These are protected by read header/payload ordering.
     system::data_chunk heading_buffer_;

--- a/src/hosts.cpp
+++ b/src/hosts.cpp
@@ -323,9 +323,15 @@ void hosts::store(const address::list& hosts, result_handler handler)
         return;
     }
 
+    mutex_.unlock_upgrade_and_lock();
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
     // Accept between 1 and all of this peer's addresses up to capacity.
     const auto capacity = buffer_.capacity();
     const auto usable = std::min(hosts.size(), capacity);
+    LOG_DEBUG(LOG_NETWORK)
+    << "hosts::store() storing up to " << usable << " host addresses from peer.";
+
     const auto random = static_cast<size_t>(
         pseudo_random::next(1, usable));
 
@@ -336,9 +342,6 @@ void hosts::store(const address::list& hosts, result_handler handler)
     // Convert minimum desired to step for iteration, no less than 1.
     const auto step = std::max(usable / accept, size_t(1));
     size_t accepted = 0;
-
-    mutex_.unlock_upgrade_and_lock();
-    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
     for (size_t index = 0; index < usable; index = ceiling_add(index, step))
     {

--- a/src/protocols/protocol_ping_31402.cpp
+++ b/src/protocols/protocol_ping_31402.cpp
@@ -61,12 +61,14 @@ void protocol_ping_31402::send_ping(const code& ec)
     if (ec && ec != error::channel_timeout)
     {
         LOG_DEBUG(LOG_NETWORK)
-            << "Failure in ping timer for [" << authority() << "] "
+            << "Failure in protocol_ping_31402 timer for [" << authority() << "] "
             << ec.message();
         stop(ec);
         return;
     }
 
+    // prior to BIP31 there is no pong reply expected, so a local TCP/IP network error condition on the attempt to send indicates failure.
+    // (i.e. local network stack error is the only possible error condition, this ping only checks locally for an active TCP connection.)
     SEND2(ping{}, handle_send, _1, ping::command);
 }
 

--- a/src/protocols/protocol_ping_60001.cpp
+++ b/src/protocols/protocol_ping_60001.cpp
@@ -39,7 +39,8 @@ using namespace std::placeholders;
 
 protocol_ping_60001::protocol_ping_60001(p2p& network, channel::ptr channel)
   : protocol_ping_31402(network, channel),
-    pending_(false),
+    nonce(0),
+    pending_(0),
     CONSTRUCT_TRACK(protocol_ping_60001)
 {
 }
@@ -47,35 +48,110 @@ protocol_ping_60001::protocol_ping_60001(p2p& network, channel::ptr channel)
 // This is fired by the callback (i.e. base timer and stop handler).
 void protocol_ping_60001::send_ping(const code& ec)
 {
+    LOG_DEBUG(LOG_NETWORK)
+    << "send_ping callback on channel with [" << authority() << "]";
+
     if (stopped(ec))
         return;
 
     if (ec && ec != error::channel_timeout)
     {
         LOG_DEBUG(LOG_NETWORK)
-            << "Failure in ping timer for [" << authority() << "] "
+            << "Failure in protocol_ping_60001 timer for [" << authority() << "] "
             << ec.message();
         stop(ec);
         return;
     }
 
-    if (pending_)
+    // active_ is set to true on each inbound message received, so we stay connected; some
+    // peers send frequent periodic ping (e.g. original recommendation was every 2 mins)
+    if (!channel_->active())
     {
-        LOG_DEBUG(LOG_NETWORK)
-            << "Ping latency limit exceeded [" << authority() << "]";
-        stop(error::channel_timeout);
-        return;
-    }
+        // pending_ means we have already sent a ping and we're waiting for the pong reply
+        // if pending_ then policy is don't burden the overloaded peer with new messages.
+        // but don't disconnect just because they have a single-minded message queue loop.
+        // do disconnect if channel has been inactive for length of two full ping timers.
+        // see https://github.com/bitcoin/bitcoin/pull/932/files
 
-    pending_ = true;
-    const auto nonce = pseudo_random::next();
-    SUBSCRIBE3(pong, handle_receive_pong, _1, _2, nonce);
-    SEND2(ping{ nonce }, handle_send_ping, _1, ping::command);
+        // pending_ is set to 1 in handle_send_ping() after a ping has been sent on the wire following the preflight queue state
+        if (pending_ > 0)
+        {
+            // Bitcoin Core will, by default, disconnect from any clients which have not responded to a ping message within 20 minutes.
+            // see https://bitcoin.org/en/developer-reference#pong
+            // here we determine whether ping response time limit has been exceeded, and give up on the peer if yes.
+            // the ping response time limit was retrieved (in protocol_ping_31402 base clase) by calling settings_.channel_heartbeat()
+            // ping timeout config file setting is channel_heartbeat_minutes
+            if (pending_ == 2)
+            {
+                LOG_DEBUG(LOG_NETWORK)
+                    << "Ping latency limit exceeded on inactive channel [" << authority() << "]";
+                stop(error::channel_timeout);
+                return;
+            }
+            else
+            {
+                // we want to wait for one complete channel heartbeat, plus time already elapsed since callback handle_send_ping occurred
+                // when channel_heartbeat_minutes == 5 this results in minimum of 5 minutes, maximum of 10 minutes for ping latency timeout.
+                // now that first channel heartbeat has occurred subsequent to handle_send_ping we trigger latency timeout on next heartbeat
+                pending_ = 2;
+                
+                LOG_DEBUG(LOG_NETWORK)
+                << "protocol_ping_60001 pending_ now = 2";
+            }
+        }
+        else if (pending_ == -1)
+        {
+            pending_ = 0; // on the next heartbeat callback, queue another ping message.
+        }
+        else
+        {
+            // nonzero nonce serves as preflight indicator, when a ping is waiting in the queue, started but not yet sent.
+            // note: BIP31 recommends sending zero nonce if the peer is never going to send multiple overlapping pings.
+            // libbitcoin may not send overlapping pings today, but this code is ready to be used in that way in the future.
+            if (nonce == 0)
+            {
+                while (nonce == 0)
+                {
+                    nonce = pseudo_random::next();
+                }
+                
+                LOG_DEBUG(LOG_NETWORK)
+                << "protocol_ping_60001 nonce now = " << nonce;
+                
+                SUBSCRIBE3(pong, handle_receive_pong, _1, _2, nonce);
+                SEND2(ping{ nonce }, handle_send_ping, _1, ping::command);
+            }
+            else
+            {
+                // many channel heartbeats may occur during the preflight state, while waiting for a queued ping to be sent such as
+                // in the condition where a channel is receiving a large number of blocks from a peer, typically during first sync.
+                // this is not a failure condition, because channel_inactivity_minutes and channel_expiration_minutes also govern.
+                // however, excessive preflight delay might be unwanted, particularly if the peer is providing useless fork blocks
+                // or unwanted transactions that won't remain canonical. a Byzantine peer seeking to cause a DoS condition may be
+                // contributing to preflight delay, but we allow this because we queue outgoing while processing incoming messages.
+                // disconnecting honest peers because of preflight delay should be avoided, so we allow channel_expiration_minutes
+                // before terminating a busy channel that is so filled with incoming messages that a ping message can never be sent.
+                // obviously, a Byzantine peer would simply respond with a pong in any case, if our ping message ever did get sent.
+                // thus better detection of unwanted low-quality messages coming from a Byzantine peer is needed here in the future.
+                
+                LOG_DEBUG(LOG_NETWORK)
+                << "protocol_ping_60001 heartbeat callback, nonzero nonce, still = " << nonce;
+            }
+        }
+    }
+    else
+    {
+        // activity on the channel before timeout will set this flag to true again
+        channel_->set_active(false);
+    }
 }
 
 void protocol_ping_60001::handle_send_ping(const code& ec,
     const std::string&)
 {
+    LOG_DEBUG(LOG_NETWORK)
+    << "handle_send_ping callback on channel with [" << authority() << "]";
+
     if (stopped(ec))
         return;
 
@@ -87,11 +163,21 @@ void protocol_ping_60001::handle_send_ping(const code& ec,
         stop(ec);
         return;
     }
+
+    channel_->set_ponged(false);
+
+    LOG_DEBUG(LOG_NETWORK)
+    << "protocol_ping_60001 pending_ now = 1";
+    
+    pending_ = 1;
 }
 
 bool protocol_ping_60001::handle_receive_ping(const code& ec,
     ping_const_ptr message)
 {
+    LOG_DEBUG(LOG_NETWORK)
+    << "handle_receive_ping callback on channel with [" << authority() << "]";
+
     if (stopped(ec))
         return false;
 
@@ -104,13 +190,49 @@ bool protocol_ping_60001::handle_receive_ping(const code& ec,
         return false;
     }
 
-    SEND2(pong{ message->nonce() }, handle_send, _1, pong::command);
+    SEND2(pong{ message->nonce() }, handle_send_pong, _1, pong::command);
+
+    channel_->set_pinged(true);
+
+    // RESUBSCRIBE
     return true;
 }
 
-bool protocol_ping_60001::handle_receive_pong(const code& ec,
-    pong_const_ptr message, uint64_t nonce)
+void protocol_ping_60001::handle_send_pong(const code& ec,
+                                        const std::string&)
 {
+    LOG_DEBUG(LOG_NETWORK)
+    << "handle_send_pong callback on channel with [" << authority() << "]";
+        
+    if (stopped(ec))
+        return;
+        
+    if (ec)
+    {
+        LOG_DEBUG(LOG_NETWORK)
+        << "Failure sending pong to [" << authority() << "] "
+        << ec.message();
+        stop(ec);
+        return;
+    }
+
+    // TODO: this isn't correct if we have overlapped inbound pings pending on the channel
+    channel_->set_pinged(false);
+
+    // active channels don't need to be pinged, nor disconnected due to ping timeout
+    // if we have sent a pong already without first sending a ping, that's unexpected.
+    // sending a pong before we send a ping will probably result in no ping being sent
+    // until and unless the channel becomes inactive. when first created the inactive
+    // state of the channel is intended to cause a ping to send at first timer event.
+    channel_->set_active(true);
+}
+
+bool protocol_ping_60001::handle_receive_pong(const code& ec,
+    pong_const_ptr message, uint64_t nonce_in)
+{
+    LOG_DEBUG(LOG_NETWORK)
+    << "handle_receive_pong callback on channel with [" << authority() << "]";
+
     if (stopped(ec))
         return false;
 
@@ -123,16 +245,33 @@ bool protocol_ping_60001::handle_receive_pong(const code& ec,
         return false;
     }
 
-    pending_ = false;
-
-    if (message->nonce() != nonce)
+    if (message->nonce() != nonce_in)
     {
+        // TODO: this presumes that the peer will always reply to pings in the sequence
+        // they were sent. that's not necessarily true, and we should be willing to accept
+        // any of the nonces we have sent out, if we do send out overlapping pings.
+        // NOTE: with the latest revision to this code we no longer send overlapped pings.
         LOG_WARNING(LOG_NETWORK)
-            << "Invalid pong nonce from [" << authority() << "]";
+            << "Invalid pong nonce = " << message->nonce() << " expecting " << nonce_in << " from [" << authority() << "]";
         stop(error::bad_stream);
         return false;
     }
+    else
+    {
+        LOG_WARNING(LOG_NETWORK)
+        << "Received valid pong nonce " << nonce_in << " from [" << authority() << "]";
+    }
 
+    channel_->set_ponged(true);
+    nonce = 0; // pong received, ready to preflight another ping
+    pending_ = -1; // don't spam the peer with unnecessry pings. skip one channel heartbeat before we queue a new ping message.
+    
+    LOG_DEBUG(LOG_NETWORK)
+    << "protocol_ping_60001 reset nonce, now = " << nonce;
+
+    // do not RESUBSCRIBE because each handler functor contains the pong's unique nonce.
+    // false return value from SUBSCRIBE3'd handler tells resubscriber not to resubscribe.
+    // see: do_invoke() in resubscriber.ipp
     return false;
 }
 


### PR DESCRIPTION
My proposal for making the Proactor design pattern more reasonable by adding a minimal state machine with awareness of the need to order certain messages and wait for pings and pongs.

For this fix to work exactly as my unit testing did, I strongly believe the default getdata size should be reduced from the 50,000 maximum, here:

https://github.com/libbitcoin/libbitcoin-node/blob/master/src/utility/reservations.cpp#L44

and be made dependent on the inventory returned from the peer, requiring the peer to tell us what they have available before we send a getdata message at all, for performance reasons and for consistency with the behavior of other Bitcoin nodes.

https://wiki.bitcoin.com/w/Protocol_specification#getdata

"getdata is used in response to inv, to retrieve the content of a specific object, and is usually sent after receiving an inv packet, after filtering known elements."

the strict Proactor design pattern of libbitcoin historically seems to have made it impossible to comply with the Bitcoin protocol documentation whenever one message type is meant to depend on the results of a previous message.

by creating a minimal hybrid Proactor + state machine for the few circumstances where message types do properly depend on each other, libbitcoin can be brought into conformity with other Bitcoin nodes, and problems such as improper timeouts negatively impacting performance and consuming resources both locally and remotely in peers' limited memory and CPU capacity without the ability to remain connected with and process messages correctly with peers will be solved.