### PR TITLE
Fix http host/origin allowlist never matching configured values

### DIFF
--- a/src/protocols/protocol_http.cpp
+++ b/src/protocols/protocol_http.cpp
@@ -348,7 +348,7 @@ bool protocol_http::is_allowed_host(const fields& fields,
     if (host.empty() && version >= version_1_1)
         return false;
 
-    return options_.hosts.empty() || contains(options_.hosts,
+    return options_.hosts.empty() || contains(options_.host_names(),
         config::to_normal_host(host, default_port()));
 }
 
@@ -365,7 +365,7 @@ bool protocol_http::is_allowed_origin(const fields& fields,
     if (origin == "null")
         return options_.allow_opaque_origin;
 
-    return options_.origins.empty() || contains(options_.origins,
+    return options_.origins.empty() || contains(options_.origin_names(),
         config::to_normal_host(origin, default_port()));
 }
 


### PR DESCRIPTION
is_allowed_host/is_allowed_origin compared the request host (normalized via to_normal_host, which substitutes default_port when the port is zero) against the raw configured endpoints in options_.hosts/origins, which are not normalized. A configured value without an explicit port (e.g. host = localhost) therefore never matched any request because the request side carried default_port (80/443) while the configured side carried port 0.

Compare against host_names()/origin_names() instead, which apply the same to_lower(default_port) normalization to the configured values, so both sides are symmetric.

Verified on a node: with host = localhost configured, Host: localhost is now accepted (was rejected), while non-listed hosts are still rejected.