### PR TITLE
Define http::body::size() to frame responses with content_length.

### DIFF
--- a/include/bitcoin/network/impl/messages/json_body.ipp
+++ b/include/bitcoin/network/impl/messages/json_body.ipp
@@ -19,6 +19,7 @@
 #ifndef LIBBITCOIN_NETWORK_MESSAGES_JSON_BODY_IPP
 #define LIBBITCOIN_NETWORK_MESSAGES_JSON_BODY_IPP
 
+#include <array>
 #include <memory>
 #include <utility>
 #include <bitcoin/network/define.hpp>
@@ -241,6 +242,47 @@ TEMPLATE
 bool CLASS::writer::done() const NOEXCEPT
 {
     return serializer_.done();
+}
+
+// json::body<>::length
+// ----------------------------------------------------------------------------
+
+TEMPLATE
+uint64_t CLASS::length(const boost::json::value& model) NOEXCEPT
+{
+    using namespace system;
+
+    // The scratch is overwritten by each read, so the serialization is
+    // measured without being materialized. The alternative is not a cheaper
+    // measure but no measure, which frames the response as chunked.
+    std::array<char, writer::default_buffer> scratch{};
+    size_t size{};
+
+    try
+    {
+        // The writer serializes the same model with the same configuration,
+        // so a model that cannot be measured here cannot be written there.
+        boost::json::serializer serializer{ model.storage() };
+        serializer.reset(&model);
+
+        while (!serializer.done())
+        {
+            const auto view = serializer.read(scratch.data(), scratch.size());
+
+            // No progress (edge case), as guarded by the writer.
+            if (view.empty())
+                return zero;
+
+            size = ceilinged_add(size, view.size());
+        }
+    }
+    catch (...)
+    {
+        // The writer performs this same serialization, so it fails likewise.
+        return zero;
+    }
+
+    return size;
 }
 
 } // namespace json

--- a/include/bitcoin/network/messages/http_body.hpp
+++ b/include/bitcoin/network/messages/http_body.hpp
@@ -104,7 +104,6 @@ using body_value = std::variant
 /// reader or writer construction, and then passes all calls through to it.
 struct BCT_API body
 {
-    /// No size(), forces chunked encoding for all types.
     /// The pass-thru body(), reader populates in construct.
     struct value_type
     {
@@ -358,6 +357,26 @@ struct BCT_API body
     private:
         body_writer writer_;
     };
+
+    /// True where the writer emits an indeterminate number of bytes, which
+    /// therefore cannot be framed with a content_length. The sender refuses
+    /// to write such a body unless the caller has set chunked encoding.
+    static bool streaming(const value_type& value) NOEXCEPT;
+
+    /// True where a zero measure cannot be a valid length: a model serializes
+    /// to at least a null (four bytes), and a peer body is written by
+    /// proxy::write(frame&&) and never framed, so it measures zero always.
+    /// A zero from either means the frame would not match the write, which
+    /// the sender refuses rather than emits.
+    static bool unframable_zero(const value_type& value) NOEXCEPT;
+
+    /// The byte count that the writer emits for the assigned inner type.
+    /// beast requires this to frame a response with a content_length, absent
+    /// which it frames from the version, chunking 1.1 and leaving 1.0
+    /// unframed. Because this is a compile time trait of the body it cannot
+    /// be selectively applied to inner types, so a streaming body is
+    /// excluded by the sender and not by the trait.
+    static uint64_t size(const value_type& value) NOEXCEPT;
 };
 
 using request = boost::beast::http::request<http::body>;

--- a/include/bitcoin/network/messages/json_body.hpp
+++ b/include/bitcoin/network/messages/json_body.hpp
@@ -27,14 +27,18 @@ namespace network {
 namespace json {
 
 /// Content passed to/from reader/writer via request/response.
-/// `static uint64_t size(const value_type&)` must be defined for beast to 
-/// produce `content_length`, otherwise the response is chunked. Predeter-
-/// mining size would have the effect of eliminating the benefit of
-/// streaming serialize.
+/// This body defines no `static uint64_t size(const value_type&)`, so beast
+/// never frames it with a content_length. The multiplexing http::body defines
+/// size() and measures this model through length() below, as beast detects a
+/// sized body as a compile time trait of the body type.
 struct json_value
 {
-    /// JSON document object model to parse/serialize.
-    boost::json::value model{};
+    /// JSON document object model to parse/serialize. Mutable because the
+    /// rpc body derives it from its message during the measure, which beast
+    /// invokes on a const body, and retains that derivation for the write
+    /// (see rpc::message_type::converted). The writer holds a non-const
+    /// reference, so nothing else requires this.
+    mutable boost::json::value model{};
 
     /// Used by channel to resize reusable buffer.
     size_t size_hint{};
@@ -111,6 +115,12 @@ struct body
         value_type& value_;
         boost::json::serializer serializer_;
     };
+
+    /// The byte count that the writer emits for the model, or zero where the
+    /// model cannot be serialized. The measure serializes as the writer does,
+    /// so a model that cannot be measured cannot be written. The serialization
+    /// is discarded as it is measured, so it is never materialized.
+    static uint64_t length(const boost::json::value& model) NOEXCEPT;
 };
 
 } // namespace json

--- a/include/bitcoin/network/messages/rpc/body.hpp
+++ b/include/bitcoin/network/messages/rpc/body.hpp
@@ -70,6 +70,14 @@ struct message_type
     /// Socket wires message termination by transport framing (tcp/ws
     /// stream messages are newline terminated, http chunks are not).
     bool terminate{};
+
+    /// Cache: the model is derived from the message, and is derived once, as
+    /// the measure and the write require the same model. A null model is a
+    /// valid derivation, so the derivation is marked rather than detected.
+    /// Assigning message after a derivation requires clearing this.
+    /// Const/mutable, not thread safe: the measure and the write are ordered
+    /// on the channel strand, which is what makes one derivation sufficient.
+    mutable bool converted{};
 };
 
 /// Derived boost::beast::http body for JSON-RPC messages.
@@ -144,6 +152,11 @@ struct BCT_API body
         bool set_prefix_{};
         bool set_close_{};
     };
+
+    /// The byte count that the writer emits for the part, including batch
+    /// framing and termination. The measure builds the model as the writer
+    /// does, so a message that cannot be measured cannot be written.
+    static uint64_t size(const value_type& value) NOEXCEPT;
 };
 
 using request_body = body<request_t>;

--- a/src/messages/http_body.cpp
+++ b/src/messages/http_body.cpp
@@ -158,6 +158,91 @@ body::writer::out_buffer body::writer::get(boost_code& ec) NOEXCEPT
     }, writer_);
 }
 
+// http::body::streaming
+// ----------------------------------------------------------------------------
+
+bool body::streaming(const value_type& value) NOEXCEPT
+{
+    // A buffer body emits an unbounded sequence of caller-supplied buffers
+    // while more is set, so its total length is not knowable here.
+    return value.contains<buffer_value>() && value.get<buffer_value>().more;
+}
+
+// http::body::unframable_zero
+// ----------------------------------------------------------------------------
+
+bool body::unframable_zero(const value_type& value) NOEXCEPT
+{
+    return value.contains<json_value>() || value.contains<rpc::request>() ||
+        value.contains<rpc::response>() || value.contains<peer_value>();
+}
+
+// http::body::size
+// ----------------------------------------------------------------------------
+// A length cannot be produced without serializing the whole model, so
+// measuring json forfeits the laziness that the streaming writer exists for.
+// The writer still streams, but it streams bytes that were measured in full
+// before the header was written. bitcoind declares a length on every
+// response, so an interface that implements it has no alternative.
+
+uint64_t body::size(const value_type& value) NOEXCEPT
+{
+    using namespace system;
+
+    // The writer assigns an empty body when the caller has assigned none.
+    if (!value.has_value())
+        return zero;
+
+    return std::visit(overload
+    {
+        [](const empty_value& value) NOEXCEPT
+        {
+            return empty_body::size(value);
+        },
+        [](const data_value& value) NOEXCEPT
+        {
+            return chunk_body::size(value);
+        },
+        [](const file_value& value) NOEXCEPT
+        {
+            return file_body::size(value);
+        },
+        [](const span_value& value) NOEXCEPT
+        {
+            return span_body::size(value);
+        },
+        [](const buffer_value& value) NOEXCEPT -> uint64_t
+        {
+            // The writer emits the assigned buffer, which is the whole body
+            // only where more is unset (a streaming body is not framable).
+            return is_null(value.data) ? zero : value.size;
+        },
+        [](const string_value& value) NOEXCEPT
+        {
+            return string_body::size(value);
+        },
+        [](const json_value& value) NOEXCEPT
+        {
+            return json_body::length(value.model);
+        },
+        [](const peer_value&) NOEXCEPT -> uint64_t
+        {
+            // A peer body is selected only by preselection (non-http) and is
+            // written by proxy::write(frame&&), so it is never framed by
+            // beast and this measure is never obtained.
+            return zero;
+        },
+        [](const rpc::request& value) NOEXCEPT
+        {
+            return rpc::request_body::size(value);
+        },
+        [](const rpc::response& value) NOEXCEPT
+        {
+            return rpc::response_body::size(value);
+        }
+    }, value.value());
+}
+
 } // namespace http
 } // namespace network
 } // namespace libbitcoin

--- a/src/messages/rpc/body.cpp
+++ b/src/messages/rpc/body.cpp
@@ -53,6 +53,67 @@ constexpr bool is_json_whitespace(char character) NOEXCEPT
         character == '\r' || character == '\n';
 }
 
+// Batch framing and message termination. get() emits these characters and
+// size() measures them, so both derive from this one declaration. The parts
+// are: a prefix on a part that opens or continues a batch, a close character
+// on the part that closes one, and a terminator where the transport wires
+// termination (tcp/ws stream messages; http chunks are not terminated), which
+// a batch carries on its close part rather than per part.
+constexpr char open = '[';
+constexpr char comma = ',';
+constexpr char close = ']';
+constexpr char line = '\n';
+constexpr uint64_t character_size = one;
+
+template <typename Value>
+constexpr uint64_t framing_size(const Value& value) NOEXCEPT
+{
+    const auto batched = opens_batch(value) || continues_batch(value);
+    const auto prefix = batched ? character_size : zero;
+    const auto close = closes_batch(value) ? character_size : zero;
+    const auto terminator = value.terminate && !batched ? character_size : zero;
+    return ceilinged_add(ceilinged_add(prefix, close), terminator);
+}
+
+// The measure and the write serialize the same model, so it is derived from
+// the message once and retained. The writer derived it a second time when the
+// measure had already done so.
+template <typename Message>
+bool derive(boost_code& ec, const message_type<Message>& value) NOEXCEPT
+{
+    ec.clear();
+    if (value.converted)
+        return true;
+
+    try
+    {
+        boost::json::value_from(value.message, value.model);
+    }
+    catch (const boost::system::system_error& e)
+    {
+        // Primary exception type for parsing operations.
+        ec = e.code();
+        return false;
+    }
+    catch (...)
+    {
+        ec = code{ error::jsonrpc_writer_exception };
+        return false;
+    }
+
+    value.converted = true;
+    return true;
+}
+
+// The measure has no code to report, and a message that cannot be derived
+// here cannot be derived by the writer, so the write fails on the same model.
+template <typename Message>
+uint64_t serialized_size(const message_type<Message>& value) NOEXCEPT
+{
+    boost_code ec{};
+    return derive(ec, value) ? body<Message>::length(value.model) : zero;
+}
+
 // rpc::body<request_t>::reader
 // ----------------------------------------------------------------------------
 // A batch is never materialized. Each read yields one element (message), with
@@ -401,21 +462,10 @@ init(boost_code& ec) NOEXCEPT
     base::writer::init(ec);
     if (ec) return;
 
-    try
-    {
-        boost::json::value_from(value_.message, value_.model);
-    }
-    catch (const boost::system::system_error& e)
-    {
-        // Primary exception type for parsing operations.
-        ec = e.code();
+    // Already derived where the measure framed a content_length, in which
+    // case this is the model that was measured.
+    if (!derive(ec, value_))
         return;
-    }
-    catch (...)
-    {
-        ec = code{ error::jsonrpc_writer_exception };
-        return;
-    }
 
     serializer_.reset(&value_.model);
 }
@@ -426,10 +476,6 @@ body<rpc::response_t>::writer::
 get(boost_code& ec) NOEXCEPT
 {
     using namespace boost::asio;
-    static constexpr auto open = '[';
-    static constexpr auto comma = ',';
-    static constexpr auto close = ']';
-    static constexpr auto line = '\n';
 
     // Buffer a single static framing character.
     const auto single = [](const char& character, bool more) NOEXCEPT
@@ -496,6 +542,19 @@ done() const NOEXCEPT
         continues_batch(value_) || !value_.terminate || set_terminator_);
 }
 
+// rpc::body<response_t>::size
+// ----------------------------------------------------------------------------
+
+// Measures the bytes emitted by get() above.
+template <>
+uint64_t body<rpc::response_t>::
+size(const value_type& value) NOEXCEPT
+{
+    // The batch close part is framing and termination only (no message).
+    const auto message = closes_batch(value) ? zero : serialized_size(value);
+    return ceilinged_add(message, framing_size(value));
+}
+
 // rpc::body<request_t>::writer
 // ----------------------------------------------------------------------------
 
@@ -506,21 +565,10 @@ init(boost_code& ec) NOEXCEPT
     base::writer::init(ec);
     if (ec) return;
 
-    try
-    {
-        boost::json::value_from(value_.message, value_.model);
-    }
-    catch (const boost::system::system_error& e)
-    {
-        // Primary exception type for parsing operations.
-        ec = e.code();
+    // Already derived where the measure framed a content_length, in which
+    // case this is the model that was measured.
+    if (!derive(ec, value_))
         return;
-    }
-    catch (...)
-    {
-        ec = code{ error::jsonrpc_writer_exception };
-        return;
-    }
 
     set_terminator_ = false;
     serializer_.reset(&value_.model);
@@ -547,8 +595,8 @@ get(boost_code& ec) NOEXCEPT
     // Add terminator and signal done.
     set_terminator_ = true;
     using namespace boost::asio;
-    static constexpr auto line = '\n';
-    return out_buffer{ std::make_pair(buffer(&line, sizeof(line)), false) };
+    return out_buffer{ std::make_pair(
+        buffer(&line, sizeof(line)), false) };
 }
 
 template <>
@@ -557,6 +605,18 @@ done() const NOEXCEPT
 {
     // Done is redundant with !out.second, but provides a cleaner interface.
     return base::writer::done() && (!value_.terminate || set_terminator_);
+}
+
+// rpc::body<request_t>::size
+// ----------------------------------------------------------------------------
+
+// Measures the bytes emitted by get() above. A notification is never batched.
+template <>
+uint64_t body<rpc::request_t>::
+size(const value_type& value) NOEXCEPT
+{
+    // A notification is never batched, so its framing is termination alone.
+    return ceilinged_add(serialized_size(value), framing_size(value));
 }
 
 BC_POP_WARNING()

--- a/src/net/proxy_actions.cpp
+++ b/src/net/proxy_actions.cpp
@@ -488,6 +488,30 @@ void proxy::write(http::response&& response,
         return;
     }
 
+    // beast frames from the header alone and never reconciles the declared
+    // length against the bytes written, so a body of indeterminate length
+    // must not be written under a content_length. The caller sets chunked
+    // encoding (which clears the length) to write one.
+    if (http::body::streaming(response.body()) && !response.chunked())
+    {
+        handler(error::bad_stream, zero);
+        return;
+    }
+
+    // A model serializes to at least a null, and a peer body is never framed,
+    // so a zero measure of either is not a length the writer will honor.
+    // Writing the header would frame an empty success for a body that does
+    // not follow it, or that follows it unframed.
+    if (http::body::unframable_zero(response.body()) && !response.chunked())
+    {
+        const auto length = response.find(http::field::content_length);
+        if (length != response.end() && length->value() == "0")
+        {
+            handler(error::bad_stream, zero);
+            return;
+        }
+    }
+
     // http batch response: header once (chunked), then response parts.
     if (batched_)
     {

--- a/test/messages/http_body_writer.cpp
+++ b/test/messages/http_body_writer.cpp
@@ -96,6 +96,224 @@ BOOST_AUTO_TEST_CASE(http_body_writer__to_writer__string__constructs_string_writ
     BOOST_REQUIRE(std::holds_alternative<string_writer>(variant));
 }
 
+// size
+// ----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(http_body__size__unassigned__zero)
+{
+    const body::value_type value{};
+    BOOST_REQUIRE_EQUAL(body::size(value), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(http_body__size__empty__zero)
+{
+    body::value_type value{};
+    value = empty_body::value_type{};
+    BOOST_REQUIRE_EQUAL(body::size(value), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(http_body__size__data__data_length)
+{
+    const chunk_body::value_type expected{ 0x2a, 0x2b, 0x2c };
+    body::value_type value{};
+    value = chunk_body::value_type{ expected };
+    BOOST_REQUIRE_EQUAL(body::size(value), expected.size());
+}
+
+// The span body requires a non-const pointer (see beast.hpp).
+BOOST_AUTO_TEST_CASE(http_body__size__span__span_length)
+{
+    std::vector<uint8_t> expected{ 0x2a, 0x2b, 0x2c };
+    body::value_type value{};
+    value = span_body::value_type{ expected.data(), expected.size() };
+    BOOST_REQUIRE_EQUAL(body::size(value), expected.size());
+}
+
+// The buffer body requires a non-const pointer (see beast.hpp).
+BOOST_AUTO_TEST_CASE(http_body__size__buffer__buffer_length)
+{
+    std::vector<uint8_t> expected{ 0x2a, 0x2b, 0x2c };
+    buffer_body::value_type buffer{};
+    buffer.data = expected.data();
+    buffer.size = expected.size();
+
+    body::value_type value{};
+    value = std::move(buffer);
+    BOOST_REQUIRE_EQUAL(body::size(value), expected.size());
+}
+
+// beast emits no bytes for an unassigned buffer, whatever size is assigned.
+BOOST_AUTO_TEST_CASE(http_body__size__buffer_unassigned_data__zero)
+{
+    const std::vector<uint8_t> unassigned{ 0x2a, 0x2b, 0x2c };
+    buffer_body::value_type buffer{};
+    buffer.size = unassigned.size();
+
+    body::value_type value{};
+    value = std::move(buffer);
+    BOOST_REQUIRE_EQUAL(body::size(value), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(http_body__size__string__string_length)
+{
+    const std::string_view expected{ "hello" };
+    body::value_type value{};
+    value = string_body::value_type{ expected };
+    BOOST_REQUIRE_EQUAL(body::size(value), expected.size());
+}
+
+BOOST_AUTO_TEST_CASE(http_body__size__json__serialized_model_length)
+{
+    const std::string_view expected{ R"({"result":42})" };
+    json_body::value_type json{};
+    json.model = boost::json::parse(expected);
+
+    body::value_type value{};
+    value = std::move(json);
+    BOOST_REQUIRE_EQUAL(body::size(value), expected.size());
+}
+
+BOOST_AUTO_TEST_CASE(http_body__size__rpc_request__message_length)
+{
+    const std::string_view expected{ R"({"jsonrpc":"2.0","method":"notify"})" };
+    rpc::request request{};
+    request.message = rpc::request_t{ rpc::version::v2, {}, "notify", {} };
+
+    body::value_type value{};
+    value = std::move(request);
+    BOOST_REQUIRE_EQUAL(body::size(value), expected.size());
+}
+
+// The http response carries no terminator, so the content_length is exactly
+// the serialized message (a stream message adds a newline terminator).
+BOOST_AUTO_TEST_CASE(http_body__size__rpc_response__message_length)
+{
+    const std::string_view expected{ R"({"jsonrpc":"2.0","id":1,"result":true})" };
+    rpc::response response{};
+    response.message = rpc::response_t{ rpc::version::v2, rpc::identity_t{ 1 }, {}, rpc::value_t{ true } };
+
+    body::value_type value{};
+    value = std::move(response);
+    BOOST_REQUIRE_EQUAL(body::size(value), expected.size());
+}
+
+// unframable_zero
+// ----------------------------------------------------------------------------
+// A model serializes to at least a null, and a peer body is never framed, so
+// a zero measure of either is not a length the writer will honor.
+
+BOOST_AUTO_TEST_CASE(http_body__unframable_zero__unassigned__false)
+{
+    const body::value_type value{};
+    BOOST_REQUIRE(!body::unframable_zero(value));
+}
+
+BOOST_AUTO_TEST_CASE(http_body__unframable_zero__string__false)
+{
+    body::value_type value{};
+    value = string_value{ "42" };
+    BOOST_REQUIRE(!body::unframable_zero(value));
+}
+
+BOOST_AUTO_TEST_CASE(http_body__unframable_zero__empty__false)
+{
+    body::value_type value{};
+    value = empty_value{};
+    BOOST_REQUIRE(!body::unframable_zero(value));
+}
+
+BOOST_AUTO_TEST_CASE(http_body__unframable_zero__json__true)
+{
+    json_body::value_type json{};
+    json.model = boost::json::parse(R"({"result":42})");
+
+    body::value_type value{};
+    value = std::move(json);
+    BOOST_REQUIRE(body::unframable_zero(value));
+}
+
+BOOST_AUTO_TEST_CASE(http_body__unframable_zero__rpc_response__true)
+{
+    rpc::response response{};
+    response.message = rpc::response_t{ rpc::version::v2, rpc::identity_t{ 1 }, {}, rpc::value_t{ true } };
+
+    body::value_type value{};
+    value = std::move(response);
+    BOOST_REQUIRE(body::unframable_zero(value));
+}
+
+BOOST_AUTO_TEST_CASE(http_body__unframable_zero__peer__true)
+{
+    body::value_type value{};
+    value = peer_value{};
+    BOOST_REQUIRE(body::unframable_zero(value));
+}
+
+BOOST_AUTO_TEST_CASE(http_body__unframable_zero__rpc_request__true)
+{
+    rpc::request request{};
+    request.message = rpc::request_t{ rpc::version::v2, rpc::identity_t{ 1 }, "method", {} };
+
+    body::value_type value{};
+    value = std::move(request);
+    BOOST_REQUIRE(body::unframable_zero(value));
+}
+
+// A null model is four bytes, so no serializable model measures zero.
+BOOST_AUTO_TEST_CASE(http_body__size__json_null_model__four)
+{
+    json_body::value_type json{};
+    json.model = boost::json::value{};
+
+    body::value_type value{};
+    value = std::move(json);
+    BOOST_REQUIRE_EQUAL(body::size(value), 4u);
+}
+
+// streaming
+// ----------------------------------------------------------------------------
+// A streaming body cannot be framed with a content_length, so the sender
+// refuses to write one that the caller has not set chunked.
+
+BOOST_AUTO_TEST_CASE(http_body__streaming__unassigned__false)
+{
+    const body::value_type value{};
+    BOOST_REQUIRE(!body::streaming(value));
+}
+
+BOOST_AUTO_TEST_CASE(http_body__streaming__string__false)
+{
+    body::value_type value{};
+    value = string_body::value_type{ "hello" };
+    BOOST_REQUIRE(!body::streaming(value));
+}
+
+BOOST_AUTO_TEST_CASE(http_body__streaming__buffer_last__false)
+{
+    std::vector<uint8_t> expected{ 0x2a, 0x2b, 0x2c };
+    buffer_body::value_type buffer{};
+    buffer.data = expected.data();
+    buffer.size = expected.size();
+    buffer.more = false;
+
+    body::value_type value{};
+    value = std::move(buffer);
+    BOOST_REQUIRE(!body::streaming(value));
+}
+
+BOOST_AUTO_TEST_CASE(http_body__streaming__buffer_more__true)
+{
+    std::vector<uint8_t> expected{ 0x2a, 0x2b, 0x2c };
+    buffer_body::value_type buffer{};
+    buffer.data = expected.data();
+    buffer.size = expected.size();
+    buffer.more = true;
+
+    body::value_type value{};
+    value = std::move(buffer);
+    BOOST_REQUIRE(body::streaming(value));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(variant_body_writer_file_body_tests, test::directory_setup_fixture)

--- a/test/messages/rpc/body_writer.cpp
+++ b/test/messages/rpc/body_writer.cpp
@@ -278,6 +278,222 @@ BOOST_AUTO_TEST_CASE(rpc_body_writer__get__batch_open_part_non_terminated__open_
     BOOST_REQUIRE(writer.done());
 }
 
+// size
+// ----------------------------------------------------------------------------
+// The size must equal the bytes that the writer emits, otherwise the beast
+// content_length frame is invalid. Each case measures the same body that it
+// then writes, comparing the two.
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__simple_response_non_terminated__message_length)
+{
+    const std::string_view expected{ R"({"jsonrpc":"2.0","id":1,"result":true})" };
+    rpc::response_body::value_type body{};
+    body.message = response_t{ version::v2, identity_t{ 1 }, {}, value_t{ true } };
+    BOOST_REQUIRE_EQUAL(rpc::response_body::size(body), expected.size());
+}
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__simple_response_terminated__message_length_with_terminator)
+{
+    const std::string_view expected_json{ R"({"jsonrpc":"2.0","id":1,"result":true})" };
+    const std::string_view expected_newline{ "\n" };
+    rpc::response_body::value_type body{};
+    body.message = response_t{ version::v2, identity_t{ 1 }, {}, value_t{ true } };
+    body.terminate = true;
+    BOOST_REQUIRE_EQUAL(rpc::response_body::size(body), expected_json.size() + expected_newline.size());
+}
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__simple_response_non_terminated__emitted_bytes)
+{
+    rpc::response_body::value_type body{};
+    body.message = response_t{ version::v2, identity_t{ 1 }, {}, value_t{ true } };
+    const auto sized = rpc::response_body::size(body);
+
+    response_header header{};
+    rpc::response_body::writer writer(header, body);
+    boost_code ec{};
+    writer.init(ec);
+    BOOST_REQUIRE(!ec);
+
+    const auto buffer = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer.has_value());
+    BOOST_REQUIRE(!buffer.get().second);
+    BOOST_REQUIRE(writer.done());
+
+    BOOST_REQUIRE_EQUAL(sized, buffer.get().first.size());
+}
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__simple_response_terminated__emitted_bytes)
+{
+    rpc::response_body::value_type body{};
+    body.message = response_t{ version::v2, identity_t{ 1 }, {}, value_t{ true } };
+    body.terminate = true;
+    const auto sized = rpc::response_body::size(body);
+
+    rpc::response_body::writer writer(body);
+    boost_code ec{};
+    writer.init(ec);
+    BOOST_REQUIRE(!ec);
+
+    const auto buffer1 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer1.has_value());
+
+    const auto buffer2 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer2.has_value());
+    BOOST_REQUIRE(!buffer2.get().second);
+    BOOST_REQUIRE(writer.done());
+
+    BOOST_REQUIRE_EQUAL(sized, buffer1.get().first.size() + buffer2.get().first.size());
+}
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__batch_open_part_terminated__emitted_bytes)
+{
+    rpc::response_body::value_type body{};
+    body.message = response_t{ version::v2, identity_t{ 1 }, {}, value_t{ true } };
+    body.changed = true;
+    body.terminate = true;
+    const auto sized = rpc::response_body::size(body);
+
+    rpc::response_body::writer writer(body);
+    boost_code ec{};
+    writer.init(ec);
+    BOOST_REQUIRE(!ec);
+
+    const auto buffer1 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer1.has_value());
+
+    const auto buffer2 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer2.has_value());
+    BOOST_REQUIRE(!buffer2.get().second);
+    BOOST_REQUIRE(writer.done());
+
+    BOOST_REQUIRE_EQUAL(sized, buffer1.get().first.size() + buffer2.get().first.size());
+}
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__batch_continuation_part_terminated__emitted_bytes)
+{
+    rpc::response_body::value_type body{};
+    body.message = response_t{ version::v2, identity_t{ 2 }, {}, value_t{ true } };
+    body.batch = true;
+    body.terminate = true;
+    const auto sized = rpc::response_body::size(body);
+
+    rpc::response_body::writer writer(body);
+    boost_code ec{};
+    writer.init(ec);
+    BOOST_REQUIRE(!ec);
+
+    const auto buffer1 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer1.has_value());
+
+    const auto buffer2 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer2.has_value());
+    BOOST_REQUIRE(!buffer2.get().second);
+    BOOST_REQUIRE(writer.done());
+
+    BOOST_REQUIRE_EQUAL(sized, buffer1.get().first.size() + buffer2.get().first.size());
+}
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__batch_close_part_terminated__emitted_bytes)
+{
+    rpc::response_body::value_type body{};
+    body.batch = true;
+    body.changed = true;
+    body.terminate = true;
+    const auto sized = rpc::response_body::size(body);
+
+    rpc::response_body::writer writer(body);
+    boost_code ec{};
+    writer.init(ec);
+    BOOST_REQUIRE(!ec);
+
+    const auto buffer1 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer1.has_value());
+
+    const auto buffer2 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer2.has_value());
+    BOOST_REQUIRE(!buffer2.get().second);
+    BOOST_REQUIRE(writer.done());
+
+    BOOST_REQUIRE_EQUAL(sized, buffer1.get().first.size() + buffer2.get().first.size());
+}
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__batch_close_part_non_terminated__emitted_bytes)
+{
+    response_header header{};
+    rpc::response_body::value_type body{};
+    body.batch = true;
+    body.changed = true;
+    const auto sized = rpc::response_body::size(body);
+
+    rpc::response_body::writer writer(header, body);
+    boost_code ec{};
+    writer.init(ec);
+    BOOST_REQUIRE(!ec);
+
+    const auto buffer = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer.has_value());
+    BOOST_REQUIRE(!buffer.get().second);
+    BOOST_REQUIRE(writer.done());
+
+    BOOST_REQUIRE_EQUAL(sized, buffer.get().first.size());
+}
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__notification_non_terminated__emitted_bytes)
+{
+    rpc::request_body::value_type body{};
+    body.message = request_t{ version::v2, {}, "notify", {} };
+    const auto sized = rpc::request_body::size(body);
+
+    request_header header{};
+    rpc::request_body::writer writer(header, body);
+    boost_code ec{};
+    writer.init(ec);
+    BOOST_REQUIRE(!ec);
+
+    const auto buffer = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer.has_value());
+    BOOST_REQUIRE(!buffer.get().second);
+    BOOST_REQUIRE(writer.done());
+
+    BOOST_REQUIRE_EQUAL(sized, buffer.get().first.size());
+}
+
+BOOST_AUTO_TEST_CASE(rpc_body__size__notification_terminated__emitted_bytes)
+{
+    rpc::request_body::value_type body{};
+    body.message = request_t{ version::v2, {}, "notify", {} };
+    body.terminate = true;
+    const auto sized = rpc::request_body::size(body);
+
+    rpc::request_body::writer writer(body);
+    boost_code ec{};
+    writer.init(ec);
+    BOOST_REQUIRE(!ec);
+
+    const auto buffer1 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer1.has_value());
+
+    const auto buffer2 = writer.get(ec);
+    BOOST_REQUIRE(!ec);
+    BOOST_REQUIRE(buffer2.has_value());
+    BOOST_REQUIRE(!buffer2.get().second);
+    BOOST_REQUIRE(writer.done());
+
+    BOOST_REQUIRE_EQUAL(sized, buffer1.get().first.size() + buffer2.get().first.size());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 ////#endif // HAVE_SLOW_TESTS

--- a/test/net/proxy.cpp
+++ b/test/net/proxy.cpp
@@ -37,6 +37,12 @@ public:
         return proxy::unconsumed(bytes, start);
     }
 
+    // Call is not stranded, as the framing guards precede the strand.
+    void write1(http::response&& response, count_handler&& handler) NOEXCEPT
+    {
+        proxy::write(std::move(response), std::move(handler));
+    }
+
     // Access protected constructor.
     mock_proxy(const socket::ptr& socket, uint32_t rate_limit=0) NOEXCEPT
       : proxy(socket, rate_limit)
@@ -299,6 +305,68 @@ BOOST_AUTO_TEST_CASE(proxy__do_subscribe_stop__subscribed__expected)
     proxy_ptr->stop(expected_ec);
     BOOST_REQUIRE_EQUAL(stop1_stopped.get_future().get(), expected_ec);
     BOOST_REQUIRE(proxy_ptr->stopped());
+}
+
+// write (framing guards)
+// ----------------------------------------------------------------------------
+// Both guards complete the handler and return without touching the socket, so
+// the socket need not be connected to observe them.
+
+static std::shared_ptr<mock_proxy> make_proxy(threadpool& pool, const logger& log) NOEXCEPT
+{
+    socket::parameters params{ .maximum_request = 42 };
+    const auto socket_ptr = std::make_shared<network::socket>(log,
+        pool.service(), std::move(params));
+    return std::make_shared<mock_proxy>(socket_ptr);
+}
+
+// A model cannot serialize to zero bytes and a peer body is never framed, so
+// a zero length from either is refused rather than framed as empty.
+BOOST_AUTO_TEST_CASE(proxy__write__unframable_zero_length__bad_stream)
+{
+    const logger log{};
+    threadpool pool(1);
+    const auto proxy_ptr = make_proxy(pool, log);
+
+    http::json_body::value_type json{};
+    json.model = boost::json::parse(R"({"result":42})");
+
+    http::response response{ http::status::ok, http::version_1_1 };
+    response.body() = std::move(json);
+    response.set(http::field::content_length, "0");
+
+    code result{ error::success };
+    proxy_ptr->write1(std::move(response),
+        [&](const code& ec, size_t) NOEXCEPT { result = ec; });
+
+    BOOST_REQUIRE_EQUAL(result, error::bad_stream);
+    proxy_ptr->stop(error::invalid_magic);
+    pool.stop();
+}
+
+// A streaming body has no length to declare, so it is refused unless chunked.
+BOOST_AUTO_TEST_CASE(proxy__write__streaming_body_unchunked__bad_stream)
+{
+    const logger log{};
+    threadpool pool(1);
+    const auto proxy_ptr = make_proxy(pool, log);
+
+    std::vector<uint8_t> bytes{ 0x2a, 0x2b, 0x2c };
+    http::buffer_value buffer{};
+    buffer.data = bytes.data();
+    buffer.size = bytes.size();
+    buffer.more = true;
+
+    http::response response{ http::status::ok, http::version_1_1 };
+    response.body() = std::move(buffer);
+
+    code result{ error::success };
+    proxy_ptr->write1(std::move(response),
+        [&](const code& ec, size_t) NOEXCEPT { result = ec; });
+
+    BOOST_REQUIRE_EQUAL(result, error::bad_stream);
+    proxy_ptr->stop(error::invalid_magic);
+    pool.stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
bs frames http responses with `Transfer-Encoding: chunked`. bitcoind never does: its writer takes the complete body and declares `Content-Length` on 1.1 always (`src/httpserver.cpp`, master). Clients of that interface reject the alternative. Against stock master, `bitcoincore-rpc` 0.19 fails `getblockcount` before dispatch: "transport error: The server replied with a chunked response which is not supported" (`rust-jsonrpc`, `src/http/simple_http.rs:225-229`). That is its default transport, and the path ord, electrs, bdk and payjoin take to a node.

This reverses the choice recorded at `http_body.hpp:100` and on `json_value`: no `size()`, so responses chunk and the serialize stays streaming. That rationale holds, and costs more than a second pass. A length cannot be produced without serializing the whole model, so declaring one forfeits the laziness the streaming writer exists for. An interface obliged to declare a length is better served serializing once and keeping the result, which is a server change that follows this one, covering the rest route; json-rpc responses continue to measure.

`http::body::size()` reports the bytes the writer emits: a length for fixed bodies, and for json a measure driving the writer's own serializer, discarded as it goes, so the text is never materialized. The json-rpc model is derived once for both the measure and the write, and the framing characters and their byte counts are declared once, so what `get()` emits is what `size()` measures. `proxy::write` refuses what it cannot frame: a buffer body with `more` set that the caller has not chunked, and a zero measure of a body that cannot legitimately be empty.

beast detects a sized body as a compile time trait of the body type, so this changes the framing default for every interface served over http, not the bitcoind route alone. A call site that wants chunked frames itself, as the batch path does. Two consequences are accepted: btcd shares the bitcoind sender and so declares a length its clients do not require, its own server declaring neither framing; and the websocket path prepares a payload whose header that transport discards.

Only a body still holding a model measures: json, and the json-rpc request and response. The six fixed alternatives report a length they hold, and a peer body is not framed here. Against chunked, which measures nothing, the measure costs what the write costs, being the same serialization: 0.27ms against 0.28ms at 500 KB, 4.2 against 4.4 at 5 MB, 33.8 against 33.8 at 29 MB (Ryzen 9 3900X, g++ 12.2 -O3, boost 1.86, system and network built at -O3 from master).

Tests assert `size()` against the bytes emitted, for the singleton and for batch open, continue and close, and cover both refusals.


