### PR TITLE
Add peer.enable_not_found setting.

### DIFF
--- a/include/bitcoin/network/settings.hpp
+++ b/include/bitcoin/network/settings.hpp
@@ -375,6 +375,7 @@ struct BCT_API settings
     bool enable_compact{ false };
     bool enable_alert{ false };
     bool enable_reject{ false };
+    bool enable_not_found{ false };
     bool enable_relay{ false };
     bool enable_privacy{ false };
     bool validate_checksum{ false };

--- a/test/settings.cpp
+++ b/test/settings.cpp
@@ -45,6 +45,7 @@ BOOST_AUTO_TEST_CASE(settings__construct__default__expected)
     BOOST_REQUIRE_EQUAL(instance.enable_compact, false);
     BOOST_REQUIRE_EQUAL(instance.enable_alert, false);
     BOOST_REQUIRE_EQUAL(instance.enable_reject, false);
+    BOOST_REQUIRE_EQUAL(instance.enable_not_found, false);
     BOOST_REQUIRE_EQUAL(instance.enable_relay, false);
     BOOST_REQUIRE_EQUAL(instance.validate_checksum, false);
     BOOST_REQUIRE_EQUAL(instance.identifier, 3652501241u);


### PR DESCRIPTION
Adds `enable_not_found` to peer settings, defaulting to false, with the settings default test.

The node cannot reply `notfound` to a peer without a setting to gate it, and the review on libbitcoin/libbitcoin-node#1106 asked for that behaviour to be routed through config and parse rather than carried as a member condition. This is the field those two changes read.
