### PR TITLE
Fix do_broadcast to notify all subscribers instead of one by sender key.

### DIFF
--- a/include/bitcoin/network/sessions/session.hpp
+++ b/include/bitcoin/network/sessions/session.hpp
@@ -68,7 +68,7 @@ private:
         {
             .method = Message::command,
             .params = { array_t{ any_t{ message }, { sender } } }
-        }, sender);
+        });
     }
 
     template <typename Handler>


### PR DESCRIPTION
`session::do_broadcast()` used the keyed single-subscriber `notify` overload, keyed by the broadcaster's own channel id — which no subscriber is ever registered under, so the notification silently matched nobody. Every broadcast, from any origin, was dropped.

Fix: use the fan-out `notify(request)` overload instead. `sender` is still passed in the message params for each subscriber's existing self-origin check.

Verified live: an Electrum-submitted tx now reaches real peers and confirms on-chain, where before it was validated and echoed back to its sender but never announced.